### PR TITLE
Fix memory leak and update dependencies

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -162,7 +162,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
      */
     await workbenchStore.saveAllFiles();
 
-    const fileModifications = workbenchStore.getFileModifcations();
+    const fileModifications = workbenchStore.getFileModifications();
 
     chatStore.setKey('aborted', false);
 

--- a/app/components/chat/CodeBlock.tsx
+++ b/app/components/chat/CodeBlock.tsx
@@ -35,6 +35,8 @@ export const CodeBlock = memo(
     };
 
     useEffect(() => {
+      let cancelled = false;
+
       if (language && !isSpecialLang(language) && !(language in bundledLanguages)) {
         logger.warn(`Unsupported language '${language}'`);
       }
@@ -42,11 +44,18 @@ export const CodeBlock = memo(
       logger.trace(`Language = ${language}`);
 
       const processCode = async () => {
-        setHTML(await codeToHtml(code, { lang: language, theme }));
+        const html = await codeToHtml(code, { lang: language, theme });
+        if (!cancelled) {
+          setHTML(html);
+        }
       };
 
       processCode();
-    }, [code]);
+
+      return () => {
+        cancelled = true;
+      };
+    }, [code, language, theme]);
 
     return (
       <div className={classNames('relative group text-left', className)}>

--- a/app/lib/hooks/useSnapScroll.ts
+++ b/app/lib/hooks/useSnapScroll.ts
@@ -18,7 +18,7 @@ export function useSnapScroll() {
           });
         }
       });
-
+      observerRef.current = observer;
       observer.observe(node);
     } else {
       observerRef.current?.disconnect();

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -202,7 +202,7 @@ export class WorkbenchStore {
     }
   }
 
-  getFileModifcations() {
+  getFileModifications() {
     return this.#filesStore.getFileModifications();
   }
 


### PR DESCRIPTION
## Summary
- fix memory leak in `useSnapScroll` ResizeObserver
- rerun syntax highlighting when `language` or `theme` change in `CodeBlock`
- rename `getFileModifcations` typo to `getFileModifications`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `npm run typecheck` *(fails: Cannot find type definition file)*