### PR TITLE
Add starter kit templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here are some tips to get the most out of Bolt.new:
 - **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Bolt scaffolds the project accordingly.
 
 - **Use the enhance prompt icon**: Before sending your prompt, try clicking the 'enhance' icon to have the AI model help you refine your prompt, then edit the results before submitting.
+- **Use starter kits**: Select a React, Vue, or Express starter from the UI to scaffold a project instantly.
 
 - **Scaffold the basics first, then add features**: Make sure the basic structure of your application is in place before diving into more advanced functionality. This helps Bolt understand the foundation of your project and ensure everything is wired up right before building out more advanced functionality.
 

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -5,6 +5,7 @@ import { Menu } from '~/components/sidebar/Menu.client';
 import { IconButton } from '~/components/ui/IconButton';
 import { Workbench } from '~/components/workbench/Workbench.client';
 import { classNames } from '~/utils/classNames';
+import { StarterKitSelector } from '~/components/templates/StarterKitSelector.client';
 import { Messages } from './Messages.client';
 import { SendButton } from './SendButton.client';
 
@@ -185,22 +186,27 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
               </div>
             </div>
             {!chatStarted && (
-              <div id="examples" className="relative w-full max-w-xl mx-auto mt-8 flex justify-center">
-                <div className="flex flex-col space-y-2 [mask-image:linear-gradient(to_bottom,black_0%,transparent_180%)] hover:[mask-image:none]">
-                  {EXAMPLE_PROMPTS.map((examplePrompt, index) => {
-                    return (
-                      <button
-                        key={index}
-                        onClick={(event) => {
-                          sendMessage?.(event, examplePrompt.text);
-                        }}
-                        className="group flex items-center w-full gap-2 justify-center bg-transparent text-bolt-elements-textTertiary hover:text-bolt-elements-textPrimary transition-theme"
-                      >
-                        {examplePrompt.text}
-                        <div className="i-ph:arrow-bend-down-left" />
-                      </button>
-                    );
-                  })}
+              <div className="space-y-6">
+                <div id="examples" className="relative w-full max-w-xl mx-auto mt-8 flex justify-center">
+                  <div className="flex flex-col space-y-2 [mask-image:linear-gradient(to_bottom,black_0%,transparent_180%)] hover:[mask-image:none]">
+                    {EXAMPLE_PROMPTS.map((examplePrompt, index) => {
+                      return (
+                        <button
+                          key={index}
+                          onClick={(event) => {
+                            sendMessage?.(event, examplePrompt.text);
+                          }}
+                          className="group flex items-center w-full gap-2 justify-center bg-transparent text-bolt-elements-textTertiary hover:text-bolt-elements-textPrimary transition-theme"
+                        >
+                          {examplePrompt.text}
+                          <div className="i-ph:arrow-bend-down-left" />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="flex justify-center">
+                  <StarterKitSelector />
                 </div>
               </div>
             )}

--- a/app/components/templates/StarterKitSelector.client.tsx
+++ b/app/components/templates/StarterKitSelector.client.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { scaffoldTemplate, templates } from '~/lib/templates';
+
+export function StarterKitSelector() {
+  const [loading, setLoading] = useState<string | null>(null);
+
+  const templateNames = Object.keys(templates) as Array<keyof typeof templates>;
+
+  return (
+    <div className="flex flex-col space-y-2">
+      {templateNames.map((name) => (
+        <button
+          key={name}
+          disabled={!!loading}
+          className="group flex items-center w-full gap-2 justify-center bg-transparent text-bolt-elements-textTertiary hover:text-bolt-elements-textPrimary transition-theme"
+          onClick={async () => {
+            setLoading(name);
+            try {
+              await scaffoldTemplate(name);
+            } finally {
+              setLoading(null);
+            }
+          }}
+        >
+          <div className={`i-logos:${name} text-xl`} />
+          {loading === name ? 'Scaffolding...' : `Start ${name}`}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/app/lib/templates.ts
+++ b/app/lib/templates.ts
@@ -1,0 +1,127 @@
+export const templates = {
+  react: {
+    'package.json': `{
+  "name": "react-app",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}`,
+    'index.html': `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>`,
+    'src/main.jsx': `import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);`,
+    'src/App.jsx': `export default function App() {
+  return <h1>Hello React!</h1>;
+}
+`,
+  },
+  vue: {
+    'package.json': `{
+  "name": "vue-app",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}`,
+    'index.html': `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Vue App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>`,
+    'src/main.js': `import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');`,
+    'src/App.vue': `<script setup>
+</script>
+
+<template>
+  <h1>Hello Vue!</h1>
+</template>
+`,
+  },
+  express: {
+    'package.json': `{
+  "name": "express-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}`,
+    'index.js': `import express from 'express';
+const app = express();
+const port = 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello Express!');
+});
+
+app.listen(port, () => {
+  console.log('Server running on http://localhost:' + port);
+});
+`,
+  },
+} as const;
+
+import { webcontainer } from '~/lib/webcontainer';
+import { WORK_DIR } from '~/utils/constants';
+import path from 'node:path';
+
+export async function scaffoldTemplate(name: keyof typeof templates) {
+  const files = templates[name];
+  const wc = await webcontainer;
+
+  for (const [filePath, content] of Object.entries(files)) {
+    const absPath = path.join(WORK_DIR, filePath);
+    const dir = path.dirname(absPath);
+    await wc.fs.mkdir(dir, { recursive: true });
+    await wc.fs.writeFile(absPath, content);
+  }
+}


### PR DESCRIPTION
## Summary
- provide minimal React, Vue and Express templates
- implement a StarterKitSelector component to scaffold templates
- show selector in BaseChat when no chat is active
- mention starter kits in README

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*
- `pnpm typecheck` *(fails: fetch failed)*